### PR TITLE
Added viewBox attribute to the generated SVG

### DIFF
--- a/org.dexpi.pid.imaging/src/org/dexpi/pid/imaging/ImageFactory_SVG.java
+++ b/org.dexpi.pid.imaging/src/org/dexpi/pid/imaging/ImageFactory_SVG.java
@@ -153,6 +153,7 @@ public class ImageFactory_SVG implements GraphicFactory {
 		// Set the width and height attributes on the root 'svg' element.
 		this.svgRoot.setAttributeNS(null, "width", "" + resolutionX);
 		this.svgRoot.setAttributeNS(null, "height", "" + resolutionY);
+		this.svgRoot.setAttributeNS(null, "viewBox", "0 0 " + resolutionX + " " + resolutionY);
 
 		this.resolutionX = resolutionX;
 		this.resolutionY = resolutionY;


### PR DESCRIPTION
For web display, the generated svg needs the have a viewBox set.
Just set it to the entire size of the generated file.